### PR TITLE
infer a prefix if the prefixes option is missing for a locale or all …

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ modules: {
 
 This module can optionally be used together with the `apostrophe-workflow` module. If so, **the workflow module must be configured first.**
 
-When workflow is present, any URL prefix for the workflow locale comes first, and the persona prefixes themselves can be localized. Here is an example.
+When workflow is present, any URL prefix for the workflow locale comes first, and the persona prefixes themselves **should** be localized. Here is an example.
 
 
 ```javascript
@@ -95,6 +95,8 @@ The resulting URLs look like:
 Both of these URLs reference the same persona, but in different locales.
 
 Since a single doc object serves all personas, the persona prefix does not become part of the slug in the database. The URL is rewritten dynamically as needed.
+
+If you do not specify the `prefixes` option, or leave out locales, a warning is printed, as an untranslated prefix is usually not what you really want.
 
 ## Constructing links to a specific persona
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,32 @@ module.exports = {
       self.personas = self.options.personas;
     };
 
+    self.modulesReady = function() {
+      var workflow = self.apos.modules['apostrophe-workflow'];
+      var inferredAll = false;
+      if (!workflow) {
+        return;
+      }
+      _.each(self.personas, function(persona) {
+        if (!persona.prefixes) {
+          persona.prefixes = {};
+          self.apos.utils.warn('Warning: workflow module is in use and the prefixes option is not configured for the ' + persona.name + ' persona, falling back to ' + persona.prefix + ' which will not be translated');
+          inferredAll = true;
+        }
+        _.each(workflow.locales, function(locale, name) {
+          if (name.match(/-draft$/)) {
+            return;
+          }
+          if (!persona.prefixes[name]) {
+            persona.prefixes[name] = persona.prefix || ('/' + persona.name);
+            if (!inferredAll) {
+              self.apos.utils.warn('Warning: workflow module is in use and the prefixes option for the ' + persona.name + ' persona has no setting for the ' + name + ' locale, falling back to ' + persona.prefix + ' which will not be translated');
+            }
+          }
+        });
+      })
+    };
+
     self.addHelpers({
       personas: function() {
         return self.personas;


### PR DESCRIPTION
…locales, but print a warning

Although you really should translate your persona prefixes, crashing later with a mysterious message is an unhelpful response to an incomplete configuration of prefix URLs for personas when workflow is active.