### PR TITLE
dcad changes for personas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.0.0
+
+* No more automatic persona switching based on previous requests (session)
+* Still put the current persona in `req.session` for backward compatibility
+* The persona `none` is now a real persona with no prefix in the urls
+* Permanent redirections are made if the request persona prefix does not match the page/piece persona
+* If a universal page is requested with no persona prefix, redirect to the first persona available
+* Author now no more see persona based content in not on the persona path unless asking it with a `showAll` parameter
+* Author will be able to select persona `none` in documents for global content
+* Added a `isPersonaUniversalContext` in `req.data` indicating if the current page has an universal persona (useful for persona switcher display in authoring)
+
 ## 2.3.7
 
 * When switching persona based on a page URL, check the relevance of the referring URL via the shared implementation that understands workflow, not a dusty copy of an older version of that function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Author now no more see persona based content in not on the persona path unless asking it with a `showAll` parameter
 * Author will be able to select persona `none` in documents for global content
 * Added a `isPersonaUniversalContext` in `req.data` indicating if the current page has an universal persona (useful for persona switcher display in authoring)
+* Added `defaultPersona` and `defaultPersonaByLocale` option to manage redirection when requesting universal content without prefix
 
 ## 2.3.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@
 * Still put the current persona in `req.session` for backward compatibility
 * The persona `none` is now a real persona with no prefix in the urls
 * Permanent redirections are made if the request persona prefix does not match the page/piece persona
-* If a universal page is requested with no persona prefix, redirect to the first persona available
+* If a universal page is requested with no persona prefix, and option `disableEmptyUniversal` is set to `true`, redirect to the first persona available or `options.defaultPersona` or `options.defaultPersonaByLocale` (reverse order)
 * Author now no more see persona based content in not on the persona path unless asking it with a `showAll` parameter
 * Author will be able to select persona `none` in documents for global content
 * Added a `isPersonaUniversalContext` in `req.data` indicating if the current page has an universal persona (useful for persona switcher display in authoring)
-* Added `defaultPersona` and `defaultPersonaByLocale` option to manage redirection when requesting universal content without prefix
 
 ## 2.3.7
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = {
   },
 
   construct: function(self, options) {
+
+    require('./lib/browser.js')(self, options);
+
     self.composePersonas = function() {
       _.each(self.options.personas, function(persona) {
         if (!persona.label) {

--- a/index.js
+++ b/index.js
@@ -246,20 +246,15 @@ module.exports = {
       return prefixes;
     };
 
-    self.userIsEditor = function(req) {
-      return req.user;
-    };
-
-    // Should return true if the user is an editor and explicitly ask for viewing all
-    // by passing a showAll query parameter and thus
+    // Should return true if the user is an editor
     // should bypass the normal restrictions on whether they
     // can see widgets and pieces for other personas, for
     // editing purposes. If this definition ("anyone who is
     // logged in is a potential editor") is not fine-grained
     // enough for your purposes, override this method at
     // project level
-    self.userIsEditorAndWantToSeeAll = function(req) {
-      return self.userIsEditor(req) && req.query.showAll;
+    self.userIsEditor = function(req) {
+      return req.user;
     };
 
     self.addMultiplePersonasMigration = function() {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,14 @@
+module.exports = function(self, options) {
+
+  self.pushAsset('script', 'always', { when: 'always' });
+
+  self.pageBeforeSend = function(req) {
+    self.pushCreateSingleton(req, 'always');
+  };
+
+  self.getCreateSingletonOptions = function(req) {
+    return {
+      currentPersona: req.persona
+    };
+  };
+};

--- a/lib/modules/apostrophe-personas-areas/index.js
+++ b/lib/modules/apostrophe-personas-areas/index.js
@@ -45,9 +45,6 @@ module.exports = {
     });
     self.inPersona = function(req, widget) {
       var persona = req.persona;
-      if (widget.personas && (widget.personas[0] === 'none')) {
-        return !req.persona;
-      }
       if (!req.persona) {
         return true;
       }

--- a/lib/modules/apostrophe-personas-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-personas-areas/lib/cursor.js
@@ -14,7 +14,9 @@ module.exports = {
           return;
         }
         var req = self.get('req');
-        if (!req.persona) req.persona = 'none';
+        if (!req.persona) {
+          req.persona = 'none';
+        }
         if (personas.userIsEditorAndWantToSeeAll(req)) {
           return;
         }

--- a/lib/modules/apostrophe-personas-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-personas-areas/lib/cursor.js
@@ -17,7 +17,7 @@ module.exports = {
         if (!req.persona) {
           req.persona = 'none';
         }
-        if (personas.userIsEditorAndWantToSeeAll(req)) {
+        if (personas.userIsEditor(req)) {
           return;
         }
         _.each(results, function(doc) {

--- a/lib/modules/apostrophe-personas-areas/lib/cursor.js
+++ b/lib/modules/apostrophe-personas-areas/lib/cursor.js
@@ -14,7 +14,8 @@ module.exports = {
           return;
         }
         var req = self.get('req');
-        if (personas.userIsEditor(req)) {
+        if (!req.persona) req.persona = 'none';
+        if (personas.userIsEditorAndWantToSeeAll(req)) {
           return;
         }
         _.each(results, function(doc) {

--- a/lib/modules/apostrophe-personas-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-personas-areas/public/js/editor.js
@@ -42,7 +42,15 @@ apos.define('apostrophe-areas-editor', {
     // down again.
     //
     // The special choice "universal" is handled specially.
+    //
+    // If current persona context would make a widget not to be displayed
+    // the widget will be displayed translucent for the author
     self.updatePersonaChoices = function($widget, selected) {
+      if (selected.length > 0 && selected[0] !== '__current' && selected.indexOf(apos.personas.currentPersona) < 0) {
+        $widget.addClass('apos-peek');
+      } else {
+        $widget.removeClass('apos-peek');
+      }
       var $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-apos-area]');
       var $select = $controls.find('[name="personas"]:first');
       if (!self.choices) {

--- a/lib/modules/apostrophe-personas-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-personas-areas/public/js/editor.js
@@ -17,9 +17,7 @@ apos.define('apostrophe-areas-editor', {
       var data = apos.areas.getWidgetData($widget);
       var matches;
       var operator;
-      /* if (persona === 'none') {
-        data.personas = [ 'none' ];
-      } else */ if (persona === '') {
+      if (persona === '') {
         data.personas = [];
       } else if (persona.match(/^[+-]/)) {
         matches = persona.match(/^([+-]) (.*)$/);
@@ -43,7 +41,7 @@ apos.define('apostrophe-areas-editor', {
     // The multiple-select capability can be seen when you pull it
     // down again.
     //
-    // The special choices "universal" is handled specially.
+    // The special choice "universal" is handled specially.
     self.updatePersonaChoices = function($widget, selected) {
       var $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-apos-area]');
       var $select = $controls.find('[name="personas"]:first');

--- a/lib/modules/apostrophe-personas-areas/public/js/editor.js
+++ b/lib/modules/apostrophe-personas-areas/public/js/editor.js
@@ -17,9 +17,9 @@ apos.define('apostrophe-areas-editor', {
       var data = apos.areas.getWidgetData($widget);
       var matches;
       var operator;
-      if (persona === 'none') {
+      /* if (persona === 'none') {
         data.personas = [ 'none' ];
-      } else if (persona === '') {
+      } else */ if (persona === '') {
         data.personas = [];
       } else if (persona.match(/^[+-]/)) {
         matches = persona.match(/^([+-]) (.*)$/);
@@ -43,8 +43,7 @@ apos.define('apostrophe-areas-editor', {
     // The multiple-select capability can be seen when you pull it
     // down again.
     //
-    // The special choices "universal" (empty array) and
-    // "no persona" (the string `none`) are handled specially.
+    // The special choices "universal" is handled specially.
     self.updatePersonaChoices = function($widget, selected) {
       var $controls = $widget.findSafe('[data-apos-widget-controls]', '[data-apos-area]');
       var $select = $controls.find('[name="personas"]:first');
@@ -54,27 +53,19 @@ apos.define('apostrophe-areas-editor', {
       $select.html('');
       if (selected.length === 0) {
         add('', '');
-        add('', 'none');
         addChoices();
       } else {
-        if (selected[0] === 'none') {
-          add('', 'none');
-          add('', '');
-          addChoices();
-        } else {
-          add('__', 'current', _.map(selected, function(value) {
-            return self.labels[value];
-          }).join(', '));
-          _.each(self.choices, function(choice) {
-            if (_.includes(selected, choice)) {
-              add('- ', choice, '✓ ' + self.labels[choice]);
-            } else {
-              add('+ ', choice, self.labels[choice]);
-            }
-          });
-          add('', '');
-          add('', 'none');
-        }
+        add('__', 'current', _.map(selected, function(value) {
+          return self.labels[value];
+        }).join(', '));
+        _.each(self.choices, function(choice) {
+          if (_.includes(selected, choice)) {
+            add('- ', choice, '✓ ' + self.labels[choice]);
+          } else {
+            add('+ ', choice, self.labels[choice]);
+          }
+        });
+        add('', '');
       }
       $select.selectedIndex = 0;
       function addChoices() {
@@ -95,7 +86,7 @@ apos.define('apostrophe-areas-editor', {
       $select.find('option').each(function() {
         var value = $(this).attr('value');
         self.labels[value] = $(this).text();
-        if (value && (value !== 'none')) {
+        if (value) {
           self.choices.push(value);
         }
       });

--- a/lib/modules/apostrophe-personas-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-personas-doc-type-manager/index.js
@@ -19,6 +19,10 @@ module.exports = {
         {
           label: 'Universal',
           value: ''
+        },
+        {
+          label: 'No Persona',
+          value: 'none'
         }
       ].concat(_.map(personas.personas, function(persona) {
         return {

--- a/lib/modules/apostrophe-personas-pages/index.js
+++ b/lib/modules/apostrophe-personas-pages/index.js
@@ -22,7 +22,11 @@ module.exports = {
       if (currentPersona !== pagePersona) {
         var personas = self.apos.modules['apostrophe-personas'];
         if (!pagePersona && !req.urlPersona && personas.personas[0]) {
-          pagePersona = personas.personas[0].name;
+          pagePersona = personas.options.defaultPersona || personas.personas[0].name;
+          var workflow = self.apos.modules['apostrophe-workflow'];
+          if (workflow && personas.options.defaultPersonaByLocale) {
+            pagePersona = personas.options.defaultPersonaByLocale[workflow.liveify(req.locale)] || pagePersona;
+          }
         }
         if (pagePersona) return req.res.redirect(301, personas.addPrefix(req, pagePersona, req.url));
       }

--- a/lib/modules/apostrophe-personas-pages/index.js
+++ b/lib/modules/apostrophe-personas-pages/index.js
@@ -16,8 +16,11 @@ module.exports = {
       // If the page/piece and the URL both have an explicit persona
       // and they don't match, redirect to the page/piece's persona
       // (none persona is here considered as explicit and should have no persona prefix)
-      // If the page/piece has universal persona and requested with no persona prefix
-      // Redirect to the first available persona
+      // If the page/piece has universal persona and requested with no persona prefix and disableEmptyUniversal is truthy
+      // Redirect to:
+      // - defaultPersonaByLocale or
+      // - defaultPersona or
+      // - first available persona
       var currentPersona = req.urlPersona || 'none';
       if (currentPersona !== pagePersona) {
         var personas = self.apos.modules['apostrophe-personas'];

--- a/lib/modules/apostrophe-personas-pages/index.js
+++ b/lib/modules/apostrophe-personas-pages/index.js
@@ -21,7 +21,7 @@ module.exports = {
       var currentPersona = req.urlPersona || 'none';
       if (currentPersona !== pagePersona) {
         var personas = self.apos.modules['apostrophe-personas'];
-        if (!pagePersona && !req.urlPersona && personas.personas[0]) {
+        if (!pagePersona && !req.urlPersona && personas.personas[0] && personas.options.disableEmptyUniversal) {
           pagePersona = personas.options.defaultPersona || personas.personas[0].name;
           var workflow = self.apos.modules['apostrophe-workflow'];
           if (workflow && personas.options.defaultPersonaByLocale) {

--- a/lib/modules/apostrophe-personas-pages/index.js
+++ b/lib/modules/apostrophe-personas-pages/index.js
@@ -11,31 +11,20 @@ module.exports = {
 
     var superPageBeforeSend = self.pageBeforeSend;
     self.pageBeforeSend = function(req, callback) {
-      var pagePersona = (req.data.piece && req.data.piece.persona) || (req.data.page && req.data.page.level && req.data.page.persona);
-      if (!req.user) {
-        if (pagePersona) {
-          // If this page or piece is locked down to one persona,
-          // set the persona for the next access per Etienne's scenario #2
-          // (but don't set req.persona now unless the referrer is ours,
-          // look carefully at scenario #2 step 1)
-          var changed = req.persona !== pagePersona;
-          if (changed) {
-            if (self.apos.modules['apostrophe-personas'].ourReferrer(req)) {
-              req.session.persona = pagePersona;
-              req.persona = req.session.persona;
-              req.data.persona = req.session.persona;
-              req.data.personaSwitched = true;
-            } else {
-              req.session.nextPersona = pagePersona;
-            }
-          }
-        }
-      }
-      // dgad-303: if the page/piece and the URL both have an explicit persona
+      var pagePersona = (req.data.piece && req.data.piece.persona) || (req.data.page && req.data.page.persona);
+      req.data.isPersonaUniversalContext = !pagePersona;
+      // If the page/piece and the URL both have an explicit persona
       // and they don't match, redirect to the page/piece's persona
-      if (pagePersona && req.urlPersona && (req.urlPersona !== pagePersona)) {
+      // (none persona is here considered as explicit and should have no persona prefix)
+      // If the page/piece has universal persona and requested with no persona prefix
+      // Redirect to the first available persona
+      var currentPersona = req.urlPersona || 'none';
+      if (currentPersona !== pagePersona) {
         var personas = self.apos.modules['apostrophe-personas'];
-        return req.res.redirect(personas.addPrefix(req, pagePersona, req.url));
+        if (!pagePersona && !req.urlPersona && personas.personas[0]) {
+          pagePersona = personas.personas[0].name;
+        }
+        if (pagePersona) return req.res.redirect(301, personas.addPrefix(req, pagePersona, req.url));
       }
       return superPageBeforeSend(req, callback);
     };
@@ -48,7 +37,7 @@ module.exports = {
 
     self.suitsPersona = function(page, persona) {
       if (!persona) {
-        return true;
+        return false;
       }
       if (!page.persona) {
         return true;

--- a/lib/modules/apostrophe-personas-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-personas-pieces/lib/cursor.js
@@ -17,7 +17,7 @@ module.exports = {
           return;
         }
         var req = self.get('req');
-        if (personas.userIsEditorAndWantToSeeAll(req)) {
+        if (personas.userIsEditor(req)) {
           return;
         }
         var persona = req.persona;

--- a/lib/modules/apostrophe-personas-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-personas-pieces/lib/cursor.js
@@ -17,7 +17,7 @@ module.exports = {
           return;
         }
         var req = self.get('req');
-        if (personas.userIsEditor(req)) {
+        if (personas.userIsEditorAndWantToSeeAll(req)) {
           return;
         }
         var persona = req.persona;

--- a/lib/modules/apostrophe-personas-widgets/index.js
+++ b/lib/modules/apostrophe-personas-widgets/index.js
@@ -50,6 +50,10 @@ module.exports = {
           {
             label: 'Unspecified',
             value: ''
+          },
+          {
+            label: 'No Persona',
+            value: 'none'
           }
         ].concat(_.map(personas.personas, function(persona) {
           return {
@@ -82,7 +86,7 @@ module.exports = {
           return callback(null);
         }
         var join = _.find(self.schema, function(field) {
-          return field.type.match(/^join/);
+          return field.type.match(/^join/) && field.withType === 'apostrophe-page';
         });
         if (!join) {
           console.error('schema has linkToPersona, but no join. Must be at same level.');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apostrophe-personas",
-  "version": "2.3.7",
-  "description": "Specialize the content of each page of an Apostrophe site based on the user's primary affiliation (employee versus employer, truck vs. car, etc)",
+  "version": "3.0.0",
+  "description": "Specialize the content of pages of an Apostrophe site based on the path prefix",
   "main": "index.js",
   "scripts": {
     "test": "mocha ./test/ && eslint ."

--- a/public/js/always.js
+++ b/public/js/always.js
@@ -1,0 +1,10 @@
+apos.define('apostrophe-personas', {
+
+  construct: function(self, options) {
+
+    self.options = options;
+    self.currentPersona = options.currentPersona;
+    apos.personas = self;
+
+  }
+});

--- a/test/behaviourTests.js
+++ b/test/behaviourTests.js
@@ -98,6 +98,7 @@ describe('Personas Module', function() {
           ]
         },
         'apostrophe-personas': {
+          disableEmptyUniversal: true,
           personas: [
             {
               name: 'tc',
@@ -141,8 +142,8 @@ describe('Personas Module', function() {
       assert(res.toJSON().body.indexOf('No persona footer') >= 0, 'See none persona content');
     });
   });
-  /* This one has changed, now based on option disableEmptyUniversal
-  it('3. Trying to reach universal page without persona prefix should redirect to first persona path', function() {
+
+  it('3. Trying to reach universal page without persona prefix should redirect to first persona path if disableEmptyUniversal', function() {
     const opts = {
       url: basePath + 'home',
       method: 'GET',
@@ -161,7 +162,7 @@ describe('Personas Module', function() {
       assert(res.toJSON().body.indexOf('No persona footer') < 0, 'TC persona DOES NOT SEE none persona content');
     });
   });
-  */
+
   it('4. Passing persona as query should redirect to persona path', function() {
     const opts = {
       url: basePath + 'home',
@@ -194,6 +195,7 @@ describe('Personas Module', function() {
     };
 
     return rp(opts, (err, res) => {
+      console.log(res.req.path);
       assert(!err);
       assert(res.statusCode === 200, 'req success');
       assert(res.req.path === '/');

--- a/test/behaviourTests.js
+++ b/test/behaviourTests.js
@@ -33,6 +33,26 @@ describe('Personas Module', function() {
               type: 'home',
               published: true,
               title: 'Home Page',
+              persona: 'none',
+              body: {
+                type: 'area',
+                items: [
+                  {
+                    _id: "footer",
+                    type: "apostrophe-rich-text",
+                    personas: ['none'],
+                    content: "<p>No persona footer</p>"
+                  }
+                ]
+              }
+            },
+            {
+              slug: '/home',
+              parkedId: 'persona-home',
+              type: 'home',
+              published: true,
+              title: 'Persona Home Page',
+              persona: '',
               body: {
                 type: 'area',
                 items: [
@@ -49,9 +69,10 @@ describe('Personas Module', function() {
                     content: "<p>TC RELATED CONTENT</p>\n"
                   },
                   {
-                    _id: "un_home",
+                    _id: "footer",
                     type: "apostrophe-rich-text",
-                    content: "<p>Universnale home page widget</p>"
+                    personas: ["none"],
+                    content: "<p>No persona footer</p>"
                   }
                 ]
               }
@@ -104,7 +125,7 @@ describe('Personas Module', function() {
     });
   });
 
-  it('2. Test initial page load -- no persona', function() {
+  it('2. Test global home page load', function() {
     const opts = {
       url: basePath,
       jar: j,
@@ -117,34 +138,13 @@ describe('Personas Module', function() {
     return rp(opts, (err, res) => {
       assert(!err);
       assert(res.statusCode === 200, 'req success');
-      assert(res.toJSON().body.indexOf('2R RELATED CONTENT') >= 0, 'Has 2R related content');
-      assert(res.toJSON().body.indexOf('TC RELATED CONTENT') >= 0, 'Has TC related content');
+      assert(res.toJSON().body.indexOf('No persona footer') >= 0, 'See none persona content');
     });
   });
 
-  it('3. Passing persona as query should set persona on session', function() {
+  it('3. Trying to reach universal page without persona prefix should redirect to first persona path', function() {
     const opts = {
-      url: basePath,
-      method: 'GET',
-      jar: j,
-      qs: {persona: 'tc'},
-      headers: {
-        Referrer: basePath
-      }
-    };
-
-    return rp(opts, (err, res) => {
-      assert(!err);
-      assert(res.statusCode === 200, 'req success');
-      assert(res.toJSON().request.uri.pathname === '/tc/');
-      assert(res.toJSON().body.indexOf('TC RELATED CONTENT' >= 0), 'TC persona sees tc related widget');
-      assert(res.toJSON().body.indexOf('2R RELATED CONTENT' < 0), 'TC persona DOES NOT SEE 2R related widget');
-    });
-  });
-
-  it('4. Subsequent visit should load persona path', function() {
-    const opts = {
-      url: basePath,
+      url: basePath + 'home',
       method: 'GET',
       jar: j,
       headers: {
@@ -155,16 +155,39 @@ describe('Personas Module', function() {
     return rp(opts, (err, res) => {
       assert(!err);
       assert(res.statusCode === 200, 'req success');
-      assert(res.req.path === '/tc/', 'Redirects to response specific path');
+      assert(res.req.path === '/tc/home');
+      assert(res.toJSON().body.indexOf('TC RELATED CONTENT') >= 0, 'TC persona sees TC related widget');
+      assert(res.toJSON().body.indexOf('2R RELATED CONTENT') < 0, 'TC persona DOES NOT SEE 2R related widget');
+      assert(res.toJSON().body.indexOf('No persona footer') < 0, 'TC persona DOES NOT SEE none persona content');
     });
   });
 
-  it('5. New session loads generic home page', function() {
+  it('4. Passing persona as query should redirect to persona path', function() {
     const opts = {
-      url: basePath,
+      url: basePath + 'home',
+      method: 'GET',
+      jar: j,
+      qs: {persona: '2r'},
+      headers: {
+        Referrer: basePath
+      }
+    };
+
+    return rp(opts, (err, res) => {
+      assert(!err);
+      assert(res.statusCode === 200, 'req success');
+      assert(res.req.path === '/2r/home');
+      assert(res.toJSON().body.indexOf('2R RELATED CONTENT') >= 0, '2R persona sees 2R related widget');
+      assert(res.toJSON().body.indexOf('TC RELATED CONTENT') < 0, '2R persona DOES NOT SEE TC related widget');
+      assert(res.toJSON().body.indexOf('No persona footer') < 0, '2R persona DOES NOT SEE none persona content');
+    });
+  });
+
+  it('5. Trying to reach global home page with persona prefix should redirect to root', function() {
+    const opts = {
+      url: basePath + 'tc',
       method: 'GET',
       jar: j1,
-
       headers: {
         Referrer: basePath
       }
@@ -173,16 +196,15 @@ describe('Personas Module', function() {
     return rp(opts, (err, res) => {
       assert(!err);
       assert(res.statusCode === 200, 'req success');
-      assert(res.toJSON().body.indexOf('ello world') >= 0, 'Has default apostrophe homepage');
-      assert(res.req.path === '/', 'loads base path');
+      assert(res.req.path === '/');
     });
   });
 
-  it('6. Visit persona page sets persona session', function() {
+  it('6. Trying to reach persona specific page without persona prefix should redirect to persona path', function() {
     const opts = {
       url: basePath + '2r-related',
       method: 'GET',
-      jar: j1,
+      jar: j,
       headers: {
         Referrer: basePath
       }
@@ -191,14 +213,15 @@ describe('Personas Module', function() {
     return rp(opts, (err, res) => {
       assert(!err);
       assert(res.statusCode === 200, 'req success');
+      assert(res.req.path === '/2r/2r-related');
     });
   });
 
-  it('7. Subsequent request is forwarded to persona url', function() {
+  it('6. Trying to reach persona specific page with bad persona prefix should redirect to persona path', function() {
     const opts = {
-      url: basePath,
+      url: basePath + 'tc/2r-related',
       method: 'GET',
-      jar: j1,
+      jar: j,
       headers: {
         Referrer: basePath
       }
@@ -207,42 +230,7 @@ describe('Personas Module', function() {
     return rp(opts, (err, res) => {
       assert(!err);
       assert(res.statusCode === 200, 'req success');
-      assert(res.req.path === '/2r/', 'Redirects to response specific path');
-    });
-  });
-
-  it('8. Visit persona page loads default page, sets cookie', function() {
-    const opts = {
-      url: basePath,
-      method: 'GET',
-      qs: {persona: 'tc'},
-      jar: j1,
-      headers: {
-        Referrer: basePath
-      }
-    };
-
-    return rp(opts, (err, res) => {
-      assert(!err);
-      assert(res.statusCode === 200, 'req success');
-      assert(res.toJSON().body.indexOf('ello world') >= 0, 'Has default apostrophe homepage');
-    });
-  });
-
-  it('9. Subsequent visit to basePath redirects to persona base', function() {
-    const opts = {
-      url: basePath,
-      method: 'GET',
-      jar: j1,
-      headers: {
-        Referrer: basePath
-      }
-    };
-
-    return rp(opts, (err, res) => {
-      assert(!err);
-      assert(res.statusCode === 200, 'req success');
-      assert(res.req.path === '/tc/', 'Redirects to persona specific path');
+      assert(res.req.path === '/2r/2r-related');
     });
   });
 });

--- a/test/behaviourTests.js
+++ b/test/behaviourTests.js
@@ -141,7 +141,7 @@ describe('Personas Module', function() {
       assert(res.toJSON().body.indexOf('No persona footer') >= 0, 'See none persona content');
     });
   });
-
+  /* This one has changed, now based on option disableEmptyUniversal
   it('3. Trying to reach universal page without persona prefix should redirect to first persona path', function() {
     const opts = {
       url: basePath + 'home',
@@ -161,7 +161,7 @@ describe('Personas Module', function() {
       assert(res.toJSON().body.indexOf('No persona footer') < 0, 'TC persona DOES NOT SEE none persona content');
     });
   });
-
+  */
   it('4. Passing persona as query should redirect to persona path', function() {
     const opts = {
       url: basePath + 'home',

--- a/test/unitTests.js
+++ b/test/unitTests.js
@@ -137,29 +137,6 @@ describe('Personas Module', function() {
     });
   });
 
-  it('test middleware - mock after persona is chosen', function (done) {
-    const module = apos.modules['apostrophe-personas'];
-    const middleware = module.expressMiddleware.middleware;
-    let req = apos.tasks.getAnonReq();
-
-    req.method = 'GET';
-    req.session = {persona: 'employee'}; // mock persona
-    req.headers = {
-      'user-agent': userAgents.desktop
-    };
-    req.data = {};
-    req.Referrer = apos.baseUrl;
-    req.url = '/foo/bar/';
-    req.res.redirect = (url) => {
-      assert(url === `/${req.session.persona}${req.url}`, 'redirects to /PERSONA/URL');
-      done();
-    };
-
-    middleware(req, req.res, () => {
-      assert();
-    });
-  });
-
   /**
    * Unit tests
    **/
@@ -217,90 +194,6 @@ describe('Personas Module', function() {
 
     const prefixed = addPrefix(req, 'employee', req.url);
     assert(prefixed === "/employee/foo/bar/");
-    done();
-  });
-
-  it('ourReferrer works', function (done) {
-    const module = apos.modules['apostrophe-personas'];
-    let req = apos.tasks.getAnonReq();
-
-    req.method = 'GET';
-    req.session = {persona: 'employee'}; // mock persona
-    req.headers = {
-      'user-agent': userAgents.desktop,
-      'Referrer': "definitely invalid"
-    };
-    req.data = {};
-    req.get = function (attr) {
-      return this.headers[attr];
-    }.bind(req);
-
-    req.url = '/foo/bar/';
-
-    assert(typeof module.ourReferrer === 'function');
-    assert(req.get('Referrer') === "definitely invalid", 'req object gets referrer');
-    assert(module.ourReferrer(req) === false, "Invalid domain fails our referrer");
-
-    req.headers = {
-      'user-agent': userAgents.desktop,
-      'Referrer': apos.baseUrl
-    };
-
-    assert(module.ourReferrer(req) === true, "domain fails our referrer");
-
-    req.headers = {
-      'user-agent': userAgents.desktop,
-      'Referrer': `${apos.baseUrl}/foo/bar/baz/etc`
-    };
-
-    assert(module.ourReferrer(req) === true, "domain fails our referrer");
-
-    done();
-  });
-
-  it('ourReferrer passes for workflow.hostnames', done => {
-    const module = apos.modules['apostrophe-personas'];
-    let req = apos.tasks.getAnonReq({host: 'en-au-undefined:8080'});
-
-    apos.modules['apostrophe-workflow'] = {
-      hostnames: {
-        'master': process.env.APP_DOMAIN,
-        'ultralite': process.env.APP_DOMAIN,
-        'ea': process.env.APP_DOMAIN,
-        'km-kh': `km-kh`,
-        'lo-la': `lo-la`,
-        'my-mm': `my-mm`,
-        'en-sg': `en-sg`,
-        'en-au': `en-au`
-      },
-      prefixes: {
-        'master': '/master',
-        'ultralite': '/ultralite',
-        'ea': '/ea'
-      }
-    };
-
-    req.method = 'GET';
-    // req.session = {persona: 'employee'}; // mock persona
-    req.headers = {
-      'user-agent': userAgents.desktop,
-      'Referrer': "http://en-au:8080/foo/bar/"
-    };
-    req.data = {};
-    req.get = function (attr) {
-      return this.headers[attr];
-    }.bind(req);
-
-    assert(req.get('Referrer') === "http://en-au:8080/foo/bar/", 'req object gets referrer');
-    assert(module.ourReferrer(req) === true, "Respect req if referrer is in workflow.hostnames");
-
-    req.headers = {
-      'user-agent': userAgents.desktop,
-      'Referrer': "http://totally-wrong:8080/foo/bar/"
-    };
-
-    assert(module.ourReferrer(req) === false, "Referrer should still fail on hostname not in baseurl or workflow.hostnames");
-
     done();
   });
 


### PR DESCRIPTION
- Authors should be able to select 'No Persona' in pages / pieces
- Authors should be able to set 'No Persona' on links target
- Generated links should be based on their persona
- Redirects based on mismatching persona in url vs page / piece persona should be permanent
- Persona module should not redirect based on session persona
- Bots should not be treated differently than real users for persona settings
- Current context Persona should be set based on url prefix
- Persona in session should be set based on url prefix
- Setting a persona on an area in author mode should make this area disappear if not in persona context
- Persona switcher should appear only for universal context
- Persona switched modal should be done client side
- Author should be able to select 'No Persona' on areas so as it appears only in 'No Persona' context
- Author should be able to select 'No Persona' with other personas so as it appears on both context
- 'Universal' pages should redirect to first available Persona if reached with an empty persona url
- Persona switcher should not propose 'Universal' persona