### PR TITLE
Apostrophe's standard "soft redirects" for changed slugs now work when a page or piece has an explicit persona setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+* Compatible with Apostrophe's "soft redirects" feature. When the slug of a page or piece that has a persona has been changed, Apostrophe can now redirect to the new slug, as long as nothing else has laid claim to the old one. Normally a standard feature, formerly this did not work in the presence of this module.
+
 ## 3.0.2
 
 * Run the personas middleware on HEAD requests as well. Thanks to Michelin for making this work possible via [Apostrophe Enterprise Support](https://apostrophecms.org/support/enterprise-support).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.3
 
-* Compatible with Apostrophe's "soft redirects" feature. When the slug of a page or piece that has a persona has been changed, Apostrophe can now redirect to the new slug, as long as nothing else has laid claim to the old one. Normally a standard feature, formerly this did not work in the presence of this module.
+* Fully compatible with Apostrophe's "soft redirects" feature. When the slug of a page or piece that has a persona has been changed, Apostrophe can now redirect to the new slug, as long as nothing else has laid claim to the old one. Normally a standard feature, formerly this did not work for pages or pieces with an explicit persona setting.
 
 ## 3.0.2
 

--- a/index.js
+++ b/index.js
@@ -188,15 +188,11 @@ module.exports = {
     // one appropriate to the given persona name.
 
     self.addPrefix = function(req, persona, url) {
-      var workflow = self.apos.modules['apostrophe-workflow'];
-      var personas = self.apos.modules['apostrophe-personas'];
-      var liveLocale = workflow && workflow.liveify(req.locale);
-      var workflowPrefix = (liveLocale && workflow.prefixes && workflow.prefixes[liveLocale]) || '';
-      if ((require('url').parse(url).pathname || '').substr(0, workflowPrefix.length) !== workflowPrefix) {
-        // Workflow prefix is not actually present, probably a route like /login
-        workflowPrefix = '';
-      }
-      var personaInfo = (persona === 'none') ? 'none' : _.find(personas.personas, { name: persona });
+      const {
+        liveLocale,
+        workflowPrefix
+      } = self.getLiveLocaleAndWorkflowPrefix(req, url);
+      var personaInfo = (persona === 'none') ? 'none' : _.find(self.personas, { name: persona });
       var prefix;
       if (personaInfo === 'none') {
         prefix = '';
@@ -285,6 +281,44 @@ module.exports = {
     };
 
     self.apos.define('apostrophe-cursor', require('./lib/cursor.js'));
+
+    self.on('apostrophe-pages:notFound', 'softRedirectWithPersona', function(req) {
+      const soft = self.apos.modules['soft-redirects'];
+      const doc = await self.apos.docs.find(req, { historicUrls: { $in: personify(req.url) } }).sort({ updatedAt: -1 }).toObject();
+      if (!doc) {
+        return;
+      }
+      if (!doc._url) {
+        return;
+      }
+      if (soft.local(doc._url) !== req.url) {
+        req.redirect = soft.local(doc._url);
+        req.statusCode = soft.options.statusCode || 302;
+      }
+      function personify(url) {
+        // URL will not contain personas yet. Personas come after
+        // workflow prefixes, if any
+        const {
+          liveLocale,
+          workflowPrefix
+        } = self.getLiveLocaleAndWorkflowPrefix(req, url);
+        
+      }
+    });
+
+    self.getLiveLocaleAndWorkflowPrefix = function(req, url) {
+      const workflow = self.apos.modules['apostrophe-workflow'];
+      const liveLocale = workflow && workflow.liveify(req.locale);
+      let workflowPrefix = (liveLocale && workflow.prefixes && workflow.prefixes[liveLocale]) || '';
+      if ((require('url').parse(url).pathname || '').substr(0, workflowPrefix.length) !== workflowPrefix) {
+        // Workflow prefix is not actually present, probably a route like /login
+        workflowPrefix = '';
+      }
+      return {
+        liveLocale,
+        workflowPrefix
+      };
+    };
 
   }
 };

--- a/index.js
+++ b/index.js
@@ -190,8 +190,8 @@ module.exports = {
     self.addPrefix = function(req, persona, url) {
       var workflow = self.apos.modules['apostrophe-workflow'];
       var personas = self.apos.modules['apostrophe-personas'];
-      var liveLocale = self.getLiveLocale();
-      var workflowPrefix = self.getWorkflowPrefix();
+      var liveLocale = workflow && workflow.liveify(req.locale);
+      var workflowPrefix = (liveLocale && workflow.prefixes && workflow.prefixes[liveLocale]) || '';
       if ((require('url').parse(url).pathname || '').substr(0, workflowPrefix.length) !== workflowPrefix) {
         // Workflow prefix is not actually present, probably a route like /login
         workflowPrefix = '';
@@ -287,7 +287,7 @@ module.exports = {
     self.apos.define('apostrophe-cursor', require('./lib/cursor.js'));
 
     self.on('apostrophe-pages:notFound', 'softRedirectWithPersona', async (req) => {
-      const soft = self.apos.modules['soft-redirects'];
+      const soft = self.apos.modules['apostrophe-soft-redirects'];
       const doc = await self.apos.docs.find(req, { historicUrls: { $in: personify(req.url) } }).sort({ updatedAt: -1 }).toObject();
       if (!doc) {
         return;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-personas#readme",
   "devDependencies": {
+    "apostrophe": "^2.49.0",
     "eslint": "^4.15.0",
     "eslint-config-punkave": "^1.0.10",
     "eslint-config-standard": "^11.0.0-beta.0",
@@ -28,9 +29,8 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^5.0.0",
-    "request": "^2.85.0",
-    "apostrophe": "^2.49.0"
+    "mocha": "^8.0.1",
+    "request": "^2.85.0"
   },
   "dependencies": {
     "request-promise": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-personas",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Specialize the content of pages of an Apostrophe site based on the path prefix, for instance employee versus employer, truck vs. car, etc.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
"Soft redirects" work by keeping a record of URLs that were actually used in the past to access this document. This interacted badly with the way the persona is stripped from the URL.